### PR TITLE
修复Cell组件Body内容过长将Footer挤出的问题

### DIFF
--- a/src/Cell/Cell.scss
+++ b/src/Cell/Cell.scss
@@ -26,7 +26,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height: pxToRem(90);
+  min-height: pxToRem(90);
   padding: pxToRem(20) pxToRem(30);
   font-size: $normalSize;
   background-color: $white;
@@ -43,6 +43,8 @@
     flex: 1;
     display: flex;
     align-items: center;
+    word-wrap: break-word;
+    word-break: break-all;
     a {
       width: 100%;
     }
@@ -50,6 +52,7 @@
   &__ft {
     display: flex;
     align-items: center;
+    margin-left: pxToRem(30)
   }
   &:after {
     content: '';


### PR DESCRIPTION
![ee0c10017b430c8084b9ba8843ed7754](https://user-images.githubusercontent.com/16443628/27669249-682e2c58-5cb8-11e7-9c5d-aa36bed94b3c.jpg)
